### PR TITLE
Add support for early versions of CIP specification

### DIFF
--- a/include/odva_ethernetip/connection.h
+++ b/include/odva_ethernetip/connection.h
@@ -92,7 +92,17 @@ public:
   /**
    * Create the forward open request from the data in this connection object
    */
-  shared_ptr<ForwardOpenRequest> createForwardOpenRequest();
+  shared_ptr<ForwardOpenRequest> createForwardOpenRequest()
+  {
+    // Maintains backwards compatability
+    return createForwardOpenRequest(false);
+  }
+
+  /**
+   * Create the forward open request from the data in this connection object
+   * @param use_legacy_forward_open_request use 16 bit connection parameters instead of news 32 bit parameters
+   */
+  shared_ptr<ForwardOpenRequest> createForwardOpenRequest(bool use_legacy_forward_open_request);
 
   /**
    * Create a forward close request from the data in this connection object

--- a/include/odva_ethernetip/session.h
+++ b/include/odva_ethernetip/session.h
@@ -88,6 +88,11 @@ public:
   void close();
 
   /**
+   * Close the session without unregistering the session and just closing the port
+   */
+  void closeWithoutUnregister();
+
+  /**
    * Get the ID number assigned to this session by the target
    * @return session ID number
    */
@@ -153,7 +158,23 @@ public:
    * @param t_to_o Target to origin connection info
    */
   int createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
-    const EIP_CONNECTION_INFO_T& t_to_o);
+    const EIP_CONNECTION_INFO_T& t_to_o)
+  {
+    // Maintains backwards compatability
+    return createConnection(o_to_t, t_to_o, 0x5B, false);
+  }
+
+  /**
+   * Create an Ethernet/IP Connection for sending implicit messages
+   * @param o_to_t Origin to target connection info
+   * @param t_to_o Target to origin connection info
+   * @param service Service code to send
+   * @param use_legacy_forward_open_request use 16 bit connection parameters instead of news 32 bit parameters
+   */
+  int createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
+    const EIP_CONNECTION_INFO_T& t_to_o,
+    EIP_USINT service,
+    bool use_legacy_forward_open_request);
 
   /**
    * Close the given connection number

--- a/include/odva_ethernetip/socket/socket.h
+++ b/include/odva_ethernetip/socket/socket.h
@@ -29,6 +29,12 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <string>
 #include <boost/asio.hpp>
 
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s)->get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s)->get_io_service())
+#endif
+
 #include "odva_ethernetip/serialization/serializable.h"
 #include "odva_ethernetip/serialization/buffer_writer.h"
 

--- a/include/odva_ethernetip/socket/tcp_socket.h
+++ b/include/odva_ethernetip/socket/tcp_socket.h
@@ -55,7 +55,7 @@ public:
    */
   virtual void open(string hostname, string port)
   {
-    tcp::resolver resolver(GET_IO_SERVICE(&socket_);
+    tcp::resolver resolver(GET_IO_SERVICE(&socket_));
     tcp::resolver::query query(hostname, port);
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
     connect(socket_, endpoint_iterator);

--- a/include/odva_ethernetip/socket/tcp_socket.h
+++ b/include/odva_ethernetip/socket/tcp_socket.h
@@ -55,7 +55,7 @@ public:
    */
   virtual void open(string hostname, string port)
   {
-    tcp::resolver resolver(socket_.get_io_service());
+    tcp::resolver resolver(GET_IO_SERVICE(&socket_);
     tcp::resolver::query query(hostname, port);
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
     connect(socket_, endpoint_iterator);

--- a/include/odva_ethernetip/socket/udp_socket.h
+++ b/include/odva_ethernetip/socket/udp_socket.h
@@ -56,7 +56,7 @@ public:
    */
   virtual void open(string hostname, string port)
   {
-    udp::resolver resolver(socket_.get_io_service());
+    udp::resolver resolver(GET_IO_SERVICE(&socket_));
     udp::resolver::query query(udp::v4(), hostname, port);
     remote_endpoint_ = *resolver.resolve(query);
     socket_.open(udp::v4());

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -56,9 +56,9 @@ void Connection::setConnectionPoints(EIP_USINT origin, EIP_USINT target)
   path_.addLogicalConnectionPoint(target);
 }
 
-shared_ptr<ForwardOpenRequest> Connection::createForwardOpenRequest()
+shared_ptr<ForwardOpenRequest> Connection::createForwardOpenRequest(bool use_legacy_forward_open_request)
 {
-  shared_ptr<ForwardOpenRequest> req = make_shared<ForwardOpenRequest> ();
+  shared_ptr<ForwardOpenRequest> req = make_shared<ForwardOpenRequest> (use_legacy_forward_open_request);
 
   req->originator_vendor_id = originator_vendor_id;
   req->originator_sn = originator_sn;

--- a/src/io_scanner.cpp
+++ b/src/io_scanner.cpp
@@ -40,6 +40,12 @@ using namespace boost::asio;
 using boost::asio::ip::udp;
 using std::endl;
 
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s)->get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s)->get_io_service())
+#endif
+
 namespace eip {
 
 using serialization::BufferReader;
@@ -60,7 +66,7 @@ IOScanner::IOScanner(io_service& io_service, string hostname)
 void IOScanner::sendListIdentityRequest()
 {
   CONSOLE_BRIDGE_logInform("Sending List Identity Request... ");
-  udp::resolver r(socket_.get_io_service());
+  udp::resolver r(GET_IO_SERVICE(&socket_));
   udp::resolver::query q(udp::v4(), hostname_, "44818");
   udp::endpoint receiver_endpoint = *r.resolve(q);
 
@@ -160,7 +166,7 @@ void IOScanner::run()
 {
   sendListIdentityRequest();
   CONSOLE_BRIDGE_logInform("Waiting for responses.");
-  socket_.get_io_service().run();
+  GET_IO_SERVICE(&socket_).run();
 }
 
 } // namespace eip

--- a/src/io_scanner.cpp
+++ b/src/io_scanner.cpp
@@ -35,16 +35,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include "odva_ethernetip/cpf_packet.h"
 #include "odva_ethernetip/cpf_item.h"
 #include "odva_ethernetip/identity_item_data.h"
+#include "odva_ethernetip/socket/socket.h"
 
 using namespace boost::asio;
 using boost::asio::ip::udp;
 using std::endl;
-
-#if BOOST_VERSION >= 107000
-#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s)->get_executor().context())
-#else
-#define GET_IO_SERVICE(s) ((s)->get_io_service())
-#endif
 
 namespace eip {
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -158,6 +158,11 @@ void Session::close()
 
   CONSOLE_BRIDGE_logInform("Session closed");
 
+  closeWithoutUnregister();
+}
+
+void Session::closeWithoutUnregister()
+{
   socket_->close();
   io_socket_->close();
   session_id_ = 0;
@@ -294,7 +299,9 @@ RRDataResponse Session::sendRRDataCommand(EIP_USINT service, const Path& path,
 }
 
 int Session::createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
-  const EIP_CONNECTION_INFO_T& t_to_o)
+  const EIP_CONNECTION_INFO_T& t_to_o,
+  EIP_USINT service,
+  bool use_legacy_forward_open_request)
 {
   Connection conn(o_to_t, t_to_o);
   conn.originator_vendor_id = my_vendor_id_;
@@ -303,8 +310,8 @@ int Session::createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
   conn.o_to_t_connection_id = next_connection_id_++;
   conn.t_to_o_connection_id = next_connection_id_++;
 
-  shared_ptr<ForwardOpenRequest> req = conn.createForwardOpenRequest();
-  RRDataResponse resp_data = sendRRDataCommand(0x5B, Path(0x06, 1), req);
+  shared_ptr<ForwardOpenRequest> req = conn.createForwardOpenRequest(use_legacy_forward_open_request);
+  RRDataResponse resp_data = sendRRDataCommand(service, Path(0x06, 1), req);
   ForwardOpenSuccess result;
   resp_data.getResponseDataAs(result);
   if (!conn.verifyForwardOpenResult(result))


### PR DESCRIPTION
Add support for early versions of CIP specification

http://read.pudn.com/downloads589/doc/2410232/CIP%20Vol1_3.3.pdf
Page 95
Section 3-5.5.1.1
connection parameters are only 16 bits